### PR TITLE
XD-2571 Get date attribute from workbookPr and use it during dates conversion

### DIFF
--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -37,5 +37,26 @@ module Creek
     def close
       @files.close
     end
+
+    def base_date
+      @base_date ||=
+      begin
+        # Default to 1900 (minus one day due to excel quirk) but use 1904 if
+        # it's set in the Workbook's workbookPr
+        # http://msdn.microsoft.com/en-us/library/ff530155(v=office.12).aspx
+        result = Date.new(1899, 12, 30) # default
+
+        doc = @files.file.open "xl/workbook.xml"
+        xml = Nokogiri::XML::Document.parse doc
+        xml.css('workbookPr[date1904]').each do |workbookPr|
+          if workbookPr['date1904'] =~ /true|1/i
+            result = Date.new(1904, 1, 1)
+            break
+          end
+        end
+
+        result
+      end
+    end
   end
 end

--- a/lib/creek/book.rb
+++ b/lib/creek/book.rb
@@ -1,9 +1,13 @@
 require 'zip/filesystem'
 require 'nokogiri'
+require 'date'
 
 module Creek
   class Creek::Book
     attr_reader :files, :sheets, :shared_strings, :cell_styles, :options
+
+    DATE_1900 = Date.new(1899, 12, 30).freeze
+    DATE_1904 = Date.new(1904, 1, 1).freeze
 
     def initialize(path, options = {})
       if options.fetch(:check_file_extension, true)
@@ -42,13 +46,13 @@ module Creek
         # Default to 1900 (minus one day due to excel quirk) but use 1904 if
         # it's set in the Workbook's workbookPr
         # http://msdn.microsoft.com/en-us/library/ff530155(v=office.12).aspx
-        result = Date.new(1899, 12, 30) # default
+        result = DATE_1900 # default
 
         doc = @files.file.open "xl/workbook.xml"
         xml = Nokogiri::XML::Document.parse doc
         xml.css('workbookPr[date1904]').each do |workbookPr|
           if workbookPr['date1904'] =~ /true|1/i
-            result = Date.new(1904, 1, 1)
+            result = DATE_1904
             break
           end
         end

--- a/lib/creek/sheet.rb
+++ b/lib/creek/sheet.rb
@@ -100,7 +100,10 @@ module Creek
     end
 
     def converter_options
-      @converter_options ||= {shared_strings: @book.shared_strings.dictionary}
+      @converter_options ||= {
+        shared_strings: @book.shared_strings.dictionary,
+        base_date: @book.base_date
+      }
     end
 
     ##

--- a/lib/creek/styles/constants.rb
+++ b/lib/creek/styles/constants.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module Creek
   class Styles
     module Constants
@@ -38,9 +36,6 @@ module Creek
         48 => :bignum,         # ##0.0E+0
         49 => :unsupported     # @
       }
-
-      DATE_SYSTEM_1900 = Date.new(1899, 12, 30)
-      DATE_SYSTEM_1904 = Date.new(1904, 1, 1)
     end
   end
 end

--- a/lib/creek/styles/converter.rb
+++ b/lib/creek/styles/converter.rb
@@ -98,21 +98,6 @@ module Creek
           value.to_f
         end
       end
-
-      ## Returns the base_date from which to calculate dates.
-      # Defaults to 1900 (minus two days due to excel quirk), but use 1904 if
-      # it's set in the Workbook's workbookPr.
-      # http://msdn.microsoft.com/en-us/library/ff530155(v=office.12).aspx
-      def base_date
-        @base_date ||= begin
-          # return DATE_SYSTEM_1900 if xml.workbook == nil
-          # xml.workbook.xpath("//workbook/workbookPr[@date1904]").each do |workbookPr|
-          #   return DATE_SYSTEM_1904 if workbookPr["date1904"] =~ /true|1/i
-          # end
-          DATE_SYSTEM_1900
-        end
-      end
-
     end
   end
 end

--- a/lib/creek/styles/converter.rb
+++ b/lib/creek/styles/converter.rb
@@ -83,7 +83,7 @@ module Creek
         fraction_of_24               = value - days_since_date_system_start
 
         # http://stackoverflow.com/questions/10559767/how-to-convert-ms-excel-date-from-float-to-date-format-in-ruby
-        date = options.fetch(:base_date, DATE_SYSTEM_1900) + days_since_date_system_start
+        date = options.fetch(:base_date, Date.new(1899, 12, 30)) + days_since_date_system_start
 
         if fraction_of_24 > 0 # there is a time associated
           seconds = (fraction_of_24 * 86400).round


### PR DESCRIPTION
[XD-2571](https://aclgrc.atlassian.net/browse/XD-2571)

There are 2 modes of dates in an excel worksheet, 1900 based and 1904 based. 1904 mode typically is enabled by default for spreadsheets created on the mac.

Creek gem didn't support 1904 based date type, that's why all imported dates were -4 years from origin.

| before fix | after fix |
| --- | --- |
| <img width="339" alt="before-fix" src="https://cloud.githubusercontent.com/assets/1645550/14705215/193f57ae-07c1-11e6-9799-26e2fc96d921.png"> | <img width="339" alt="after-fix" src="https://cloud.githubusercontent.com/assets/1645550/14705226/1f5d81ba-07c1-11e6-95a9-ab51baaa38c1.png"> |
