### PR TITLE
XD-2695 Add date time support

### DIFF
--- a/lib/creek/styles/converter.rb
+++ b/lib/creek/styles/converter.rb
@@ -87,10 +87,20 @@ module Creek
 
         if fraction_of_24 > 0 # there is a time associated
           seconds = (fraction_of_24 * 86400).round
-          return Time.utc(date.year, date.month, date.day) + seconds
+          time = create_time(date) + seconds
+
+          time.year == 1899 ? time : create_date_time(time)
         else
-          return date
+          date
         end
+      end
+
+      def self.create_time(date)
+        Time.utc(date.year, date.month, date.day)
+      end
+
+      def self.create_date_time(time)
+        DateTime.civil(time.year, time.month, time.day, time.hour, time.min, time.sec)
       end
 
       def self.convert_bignum(value)

--- a/spec/styles/converter_spec.rb
+++ b/spec/styles/converter_spec.rb
@@ -39,12 +39,24 @@ describe Creek::Styles::Converter do
       it { is_expected.to be_truthy }
     end
 
-    context "when type is date time" do
+    context "when type is date" do
       let(:value) { "41275" }
       let(:type) { "n" }
       let(:style) { :date_time }
 
       it { is_expected.to eq Date.new(2013, 01, 01) }
+
+      context "when type is time" do
+        let(:value) { "0.3833333333333333" }
+
+        it { is_expected.to eq Time.utc(1899, 12, 30, 9, 12) }
+      end
+
+      context "when type is date time" do
+        let(:value) { "40910.5" }
+
+        it { is_expected.to eq DateTime.civil(2012, 1, 2, 12, 0) }
+      end
     end
   end
 end


### PR DESCRIPTION
[XD-2695](https://aclgrc.atlassian.net/browse/XD-2695)

Creek didn't support `DateTime`, so values like `12:30:05` or `02/01/12 12:30:05` were saved as a `Time` objects.

In this PR I've introduced logic that looks to the date and determines whether it's just a time or contains a date part too. In Ruby there is no any way to store only time, so that's why I am checking equality of year to default.

before:
<img width="736" alt="before" src="https://cloud.githubusercontent.com/assets/1645550/15759887/75e67e1e-2919-11e6-88d9-59aa236bc1f0.png">

after:
<img width="792" alt="after" src="https://cloud.githubusercontent.com/assets/1645550/15759896/7bd50f7a-2919-11e6-833e-fa02ed0905ed.png">
