### PR TITLE
XD-3662 Upgrades nokogiri dependency to ~> 1.7.1 to include fixed CVE

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.13.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'nokogiri', '~> 1.6.0'
+  spec.add_dependency 'nokogiri', '~> 1.7.1'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
 end


### PR DESCRIPTION
Name: nokogiri
Version: 1.6.8.1
Advisory: CVE-2016-4658
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1615
Title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
Solution: upgrade to >= 1.7.1

Vulnerabilities found!